### PR TITLE
xoto3 1.4 - more informative Item get/put/update exceptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,12 @@
+### 1.4.0
+
+- Improved DynamoDB Item-related Exceptions for `GetItem`,
+  `put_but_raise_if_exists`, and `versioned_diffed_update_item`.
+
 ### 1.3.3
 
 - Allow any characters for attribute names in `add_variables_to_expression`.
-  * We have a lot of snake_cased attribute names. We should be able to use this function with those.  
+  - We have a lot of snake_cased attribute names. We should be able to use this function with those.
 
 ### 1.3.2
 

--- a/tests/xoto3/dynamodb/exceptions_test.py
+++ b/tests/xoto3/dynamodb/exceptions_test.py
@@ -1,0 +1,38 @@
+import pytest
+
+from xoto3.dynamodb.exceptions import (
+    get_item_exception_type,
+    raise_if_empty_getitem_response,
+    ItemNotFoundException,
+    ItemAlreadyExistsException,
+    AlreadyExistsException,
+)
+
+
+def test_dynamically_named_exceptions_names_and_caches_different_types():
+    media_not_found = get_item_exception_type("Media", ItemNotFoundException)
+
+    assert media_not_found.__name__ == "MediaNotFoundException"
+    assert issubclass(media_not_found, ItemNotFoundException)
+
+    assert get_item_exception_type("Media", ItemNotFoundException) is media_not_found
+
+    media_already_exists = get_item_exception_type("Media", ItemAlreadyExistsException)
+    assert issubclass(media_already_exists, AlreadyExistsException)
+    assert media_already_exists.__name__ == "MediaAlreadyExistsException"
+    assert not issubclass(media_already_exists, ItemNotFoundException)
+
+
+def test_raises_uses_nicename():
+    with pytest.raises(ItemNotFoundException) as infe_info:
+        raise_if_empty_getitem_response(dict(), nicename="Duck")
+    assert infe_info.value.__class__.__name__ == "DuckNotFoundException"
+
+
+def test_raises_includes_key_and_table_name():
+    with pytest.raises(ItemNotFoundException) as infe_info:
+        raise_if_empty_getitem_response(
+            dict(), nicename="Plant", table_name="Greenhouse", key=dict(id="p0001")
+        )
+    assert infe_info.value.key == dict(id="p0001")
+    assert infe_info.value.table_name == "Greenhouse"

--- a/tests/xoto3/dynamodb/put_test.py
+++ b/tests/xoto3/dynamodb/put_test.py
@@ -1,0 +1,39 @@
+import os
+import random
+
+import pytest
+import boto3
+
+import xoto3.dynamodb.put as xput
+
+from tests.xoto3.dynamodb.testing_utils import make_pytest_put_fixture_for_table
+
+
+XOTO3_INTEGRATION_TEST_ID_TABLE_NAME = os.environ.get(
+    "XOTO3_INTEGRATION_TEST_DYNAMODB_ID_TABLE_NAME"
+)
+
+
+_INTEGRATION_ID_TABLE = (
+    boto3.resource("dynamodb").Table(XOTO3_INTEGRATION_TEST_ID_TABLE_NAME)
+    if XOTO3_INTEGRATION_TEST_ID_TABLE_NAME
+    else None
+)
+integration_table_put = make_pytest_put_fixture_for_table(_INTEGRATION_ID_TABLE)
+
+
+@pytest.mark.skipif(
+    not XOTO3_INTEGRATION_TEST_ID_TABLE_NAME, reason="No integration id table was defined"
+)
+def test_put_already_exists(integration_table_put):
+
+    random_key = dict(id=str(random.randint(9999999, 999999999999999999999)))
+    item = dict(random_key, test_item_please_ignore=True)
+    integration_table_put(item)
+
+    with pytest.raises(xput.ItemAlreadyExistsException) as ae_info:
+        xput.put_but_raise_if_exists(
+            _INTEGRATION_ID_TABLE, dict(item, new_attribute="testing attr"), nicename="TestThing"
+        )
+
+    assert ae_info.value.__class__.__name__ == "TestThingAlreadyExistsException"

--- a/tests/xoto3/dynamodb/testing_utils.py
+++ b/tests/xoto3/dynamodb/testing_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from xoto3.dynamodb.put import PutItem
+from xoto3.dynamodb.types import TableResource, InputItem
+from xoto3.dynamodb.utils.table import extract_key_from_item
+
+
+def make_pytest_put_fixture_for_table(table: TableResource):
+    @pytest.fixture
+    def put_item_fixture():
+        keys_put = list()
+
+        def _put_item(item: InputItem):
+            keys_put.append(extract_key_from_item(table, item))
+            PutItem(table, item)
+
+        yield _put_item
+
+        for key in keys_put:
+            table.delete_item(Key=key)
+
+    return put_item_fixture

--- a/xoto3/__about__.py
+++ b/xoto3/__about__.py
@@ -1,4 +1,4 @@
 """xoto3"""
-__version__ = "1.3.3"
+__version__ = "1.4.0"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"

--- a/xoto3/cloudformation/__init__.py
+++ b/xoto3/cloudformation/__init__.py
@@ -13,7 +13,8 @@ _NAMED_OUTPUTS: ty.Dict[str, str] = dict()
 
 def _get_cached_stack(stack_name: str):
     if stack_name not in _STACKS:
-        _STACKS[stack_name] = _CF_RESOURCE().Stack(stack_name)
+        stack = _CF_RESOURCE().Stack(stack_name)  # type: ignore
+        _STACKS[stack_name] = stack
     return _STACKS[stack_name]
 
 

--- a/xoto3/cloudwatch/metrics.py
+++ b/xoto3/cloudwatch/metrics.py
@@ -105,7 +105,7 @@ class MetricPutter:
 
         metric_dict = dict(Namespace=self.namespace, MetricData=[metric_data])
         logger.debug("put_metric", extra=dict(put_metric=metric_dict))
-        CLOUDWATCH_CLIENT().put_metric_data(**metric_dict)
+        CLOUDWATCH_CLIENT().put_metric_data(**metric_dict)  # type: ignore
 
 
 PutMetricReturner = ty.Callable[..., float]

--- a/xoto3/dynamodb/exceptions.py
+++ b/xoto3/dynamodb/exceptions.py
@@ -1,5 +1,8 @@
 """Exceptions for our Dynamo usage"""
+from typing import Optional, TypeVar, Type, Dict, Tuple
 import botocore.exceptions
+
+from .types import ItemKey
 
 
 class DynamoDbException(Exception):
@@ -8,20 +11,64 @@ class DynamoDbException(Exception):
     pass
 
 
-class AlreadyExistsException(DynamoDbException):
+class DynamoDbItemException(DynamoDbException):
+    def __init__(self, msg: str, *, key: Optional[ItemKey] = None, table_name: str = "", **kwargs):
+        self.__dict__.update(kwargs)
+        self.key = key
+        self.table_name = table_name
+        super().__init__(msg)
+
+
+class AlreadyExistsException(DynamoDbItemException):
+    """Deprecated - prefer ItemAlreadyExistsException"""
+
     pass
 
 
-class ItemNotFoundException(DynamoDbException):
+class ItemAlreadyExistsException(AlreadyExistsException):
+    """Backwards-compatible, more consistent name"""
+
+    pass
+
+
+class ItemNotFoundException(DynamoDbItemException):
     """Being more specific that an item was not found"""
 
+    pass
 
-def raise_if_empty_getitem_response(getitem_response: dict, nicename="Item", key=None):
-    """Boto3 does not raise any error if the item could not be found"""
+
+X = TypeVar("X", bound=DynamoDbItemException)
+
+
+_GENERATED_ITEM_EXCEPTION_TYPES: Dict[Tuple[str, str], type] = {
+    ("Item", "ItemNotFoundException"): ItemNotFoundException
+}
+
+
+def get_item_exception_type(item_name: str, base_exc: Type[X]) -> Type[X]:
+    if not item_name:
+        return base_exc
+    base_name = base_exc.__name__
+    exc_key = (item_name, base_exc.__name__)
+    if exc_key not in _GENERATED_ITEM_EXCEPTION_TYPES:
+        exc_minus_Item = base_name[4:] if base_name.startswith("Item") else base_name
+        _GENERATED_ITEM_EXCEPTION_TYPES[exc_key] = type(
+            f"{item_name}{exc_minus_Item}", (base_exc,), dict()
+        )
+    return _GENERATED_ITEM_EXCEPTION_TYPES[exc_key]
+
+
+def raise_if_empty_getitem_response(
+    getitem_response: dict, nicename="Item", key=None, table_name: str = ""
+):
+    """Boto3 does not raise any error if the item could not be found. This
+    is not what we want in many cases, and it's convenient to have a
+    standard way of identifying ItemNotFound.
+    """
+    exception = get_item_exception_type(nicename, ItemNotFoundException)
     if "Item" not in getitem_response:
-        if "id" in key and len(key) == 1:
-            key = key["id"]
-        raise ItemNotFoundException(f"{nicename} '{key}' does not exist!")
+        key_value = next(iter(key.values())) if key and len(key) == 1 else key
+        raise exception(f"{nicename} '{key_value}' does not exist!", key=key, table_name=table_name)
 
 
 def translate_clienterrors(client_error: botocore.exceptions.ClientError, names_to_messages: dict):

--- a/xoto3/dynamodb/exceptions.py
+++ b/xoto3/dynamodb/exceptions.py
@@ -8,8 +8,6 @@ from .types import ItemKey
 class DynamoDbException(Exception):
     """Wrapping error responses from Dynamo DB"""
 
-    pass
-
 
 class DynamoDbItemException(DynamoDbException):
     def __init__(self, msg: str, *, key: Optional[ItemKey] = None, table_name: str = "", **kwargs):
@@ -22,19 +20,13 @@ class DynamoDbItemException(DynamoDbException):
 class AlreadyExistsException(DynamoDbItemException):
     """Deprecated - prefer ItemAlreadyExistsException"""
 
-    pass
-
 
 class ItemAlreadyExistsException(AlreadyExistsException):
     """Backwards-compatible, more consistent name"""
 
-    pass
-
 
 class ItemNotFoundException(DynamoDbItemException):
     """Being more specific that an item was not found"""
-
-    pass
 
 
 X = TypeVar("X", bound=DynamoDbItemException)

--- a/xoto3/dynamodb/exceptions.py
+++ b/xoto3/dynamodb/exceptions.py
@@ -65,10 +65,11 @@ def raise_if_empty_getitem_response(
     is not what we want in many cases, and it's convenient to have a
     standard way of identifying ItemNotFound.
     """
-    exception = get_item_exception_type(nicename, ItemNotFoundException)
     if "Item" not in getitem_response:
         key_value = next(iter(key.values())) if key and len(key) == 1 else key
-        raise exception(f"{nicename} '{key_value}' does not exist!", key=key, table_name=table_name)
+        raise get_item_exception_type(nicename, ItemNotFoundException)(
+            f"{nicename} '{key_value}' does not exist!", key=key, table_name=table_name
+        )
 
 
 def translate_clienterrors(client_error: botocore.exceptions.ClientError, names_to_messages: dict):

--- a/xoto3/dynamodb/get.py
+++ b/xoto3/dynamodb/get.py
@@ -16,7 +16,7 @@ def GetItem(Table: TableResource, Key: ItemKey, nicename="Item", **kwargs) -> It
     """
     logger.debug(f"Get{nicename} {Key} from Table {Table.name}")
     response = Table.get_item(Key={**Key}, **kwargs)
-    raise_if_empty_getitem_response(response, nicename, key=Key)
+    raise_if_empty_getitem_response(response, nicename=nicename, key=Key, table_name=Table.name)
     return response["Item"]
 
 

--- a/xoto3/dynamodb/update/utils.py
+++ b/xoto3/dynamodb/update/utils.py
@@ -19,6 +19,7 @@ def logged_update_item(
     except Exception as e:
         # verbose logging if an error occurs
         logger.info("UpdateItem arguments", extra=dict(json=dict(update_args)))
+        e.update_item_arguments = update_args  # type: ignore
         raise e
 
 

--- a/xoto3/dynamodb/update/versioned.py
+++ b/xoto3/dynamodb/update/versioned.py
@@ -18,7 +18,7 @@ from botocore.exceptions import ClientError
 from xoto3.errors import client_error_name
 from xoto3.utils.dt import iso8601strict
 from xoto3.utils.tree_map import SimpleTransform
-from xoto3.dynamodb.exceptions import DynamoDbItemException
+from xoto3.dynamodb.exceptions import DynamoDbItemException, get_item_exception_type
 from xoto3.dynamodb.types import TableResource
 from xoto3.dynamodb.get import strongly_consistent_get_item
 from xoto3.dynamodb.types import ItemKey, Item, AttrDict
@@ -73,7 +73,7 @@ UpdateOrCreateItem = partial(UpdateItem, condition_exists=False)
 def versioned_diffed_update_item(
     table: TableResource,
     item_transformer: ItemTransformer,
-    item_id: ItemKey,
+    item_key: ItemKey = None,
     *,
     get_item: ItemGetter = strongly_consistent_get_item,
     update_item: ItemUpdater = UpdateOrCreateItem,
@@ -82,6 +82,8 @@ def versioned_diffed_update_item(
     last_written_key: str = "last_written_at",
     random_sleep_on_lost_race: bool = True,
     prewrite_transform: ty.Optional[SimpleTransform] = _DEFAULT_PREDIFF_TRANSFORM,
+    item_id: ItemKey = None,  # deprecated name, present for backward-compatibility
+    nicename: str = "Item",
 ) -> Item:
     """Performs an item read-transform-write loop until there are no intervening writes.
 
@@ -101,12 +103,15 @@ def versioned_diffed_update_item(
     will revert to fetching if the transaction fails because of an
     intervening write.
     """
+    item_key = item_key or item_id
+    assert item_key, "Must pass item_key or (deprecated) item_id"
+
     attempt = 0
     max_attempts_before_failure = int(max(1, max_attempts_before_failure))
     update_arguments = None
     while attempt < max_attempts_before_failure:
         attempt += 1
-        item = get_item(table, item_id)
+        item = get_item(table, item_key)
         cur_item_version = item.get(item_version_key, 0)
 
         logger.debug(f"Current item version is {cur_item_version}")
@@ -114,13 +119,13 @@ def versioned_diffed_update_item(
         # do the incremental update
         updated_item = item_transformer(copy.deepcopy(item))
         if not updated_item:
-            logger.debug("No transformed item was returned; returning original item")
+            logger.debug(f"No transformed {nicename} was returned; returning original {nicename}")
             return item
         assert updated_item is not None
         item_diff = build_update_diff(item, updated_item, prediff_transform=prewrite_transform)
         if not item_diff:
             logger.info(
-                "A transformed item was returned but no meaningful difference was found.",
+                f"Transformed {nicename} was returned but no meaningful difference was found.",
                 extra=dict(json=dict(item=item, updated_item=updated_item)),
             )
             return item
@@ -138,17 +143,17 @@ def versioned_diffed_update_item(
             expr = versioned_item_expression(
                 cur_item_version,
                 item_version_key,
-                id_that_exists=next(iter(item_id.keys())) if item else "",
+                id_that_exists=next(iter(item_key.keys())) if item else "",
             )
             logger.debug(expr)
             update_arguments = select_attributes_for_set_and_remove(item_diff)
             # store arguments for later logging
-            update_item(table, item_id, **update_arguments, **expr)
+            update_item(table, item_key, **update_arguments, **expr)
             return updated_item
         except ClientError as ce:
             if client_error_name(ce) == "ConditionalCheckFailedException":
                 msg = (
-                    "Attempt %d to update item in table %s was beaten "
+                    "Attempt %d to update %s in table %s was beaten "
                     + "by a different update. Sleeping for %s seconds."
                 )
                 sleep = 0.0
@@ -158,18 +163,19 @@ def versioned_diffed_update_item(
                 logger.warning(
                     msg,
                     attempt,
+                    nicename,
                     table.name,
                     f"{sleep:.3f}",
                     extra=dict(
-                        json=dict(item_id=item_id, item_diff=item_diff, ce=str(ce), sleep=sleep)
+                        json=dict(item_key=item_key, item_diff=item_diff, ce=str(ce), sleep=sleep)
                     ),
                 )
             else:
                 raise
-    raise VersionedUpdateFailure(
-        f"Failed to update item without performing overwrite {item_id}. "
+    raise get_item_exception_type(nicename, VersionedUpdateFailure)(
+        f"Failed to update {nicename} without performing overwrite {item_key}. "
         f"Was beaten to the update {attempt} times.",
-        key=item_id,
+        key=item_key,
         table_name=table.name,
         update_arguments=update_arguments,
     )

--- a/xoto3/dynamodb/utils/table.py
+++ b/xoto3/dynamodb/utils/table.py
@@ -1,10 +1,10 @@
 from typing import Tuple
-from xoto3.dynamodb.types import TableResource, Item, ItemKey
+from xoto3.dynamodb.types import TableResource, InputItem, ItemKey
 
 
 def table_primary_keys(table: TableResource) -> Tuple[str, ...]:
     return tuple([key["AttributeName"] for key in table.key_schema])
 
 
-def extract_key_from_item(table: TableResource, item: Item) -> ItemKey:
+def extract_key_from_item(table: TableResource, item: InputItem) -> ItemKey:
     return {attr_name: item[attr_name] for attr_name in table_primary_keys(table)}


### PR DESCRIPTION
This provides new functionality based on the "nicename" concept for
both GetItem and put_but_raise_if_exists.

It also stores some useful information inside the exception so that
loggers and upstream processors of exceptions will automatically have
more information about what failed without the need to have the
intermediate calling code catch and rethrow, or otherwise modify the
calling context to provide that information.