### PR TITLE
Accept a table_name_map in versioned_transact_write_items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### 1.11.0
+
+- Allow a table_name_map to be passed in so that knowledge of the actual
+  table name being acted upon can remain in only the imperative shell of
+  an application using versioned_transact_write_items.
+
 ### 1.10.1
 
 - Fixed bug in `versioned_transact_write_items` where un-effected

--- a/tests/xoto3/dynamodb/write_versioned/transact/ddb_api_test.py
+++ b/tests/xoto3/dynamodb/write_versioned/transact/ddb_api_test.py
@@ -87,3 +87,27 @@ def test_built_transaction_includes_unmodified():
             },
         ]
     } == args
+
+
+def test_built_transaction_accepts_table_name_map():
+
+    tx = VersionedTransaction(
+        tables=dict(
+            Common=items_and_keys_to_clean_table_data(
+                ("id",), [dict(id="unmodified")], [dict(id="delete", val=4)]
+            )
+        )
+    )
+    tx = delete(tx, "Common", dict(id="delete"))
+
+    args = built_transaction_to_transact_write_items_args(
+        tx, "adatetimestring", table_name_map=dict(Common="VisionCommon.testing.dynamo.table.v00")
+    )
+
+    assert (
+        args["TransactItems"][0]["Delete"]["TableName"] == "VisionCommon.testing.dynamo.table.v00"
+    )
+    assert (
+        args["TransactItems"][1]["ConditionCheck"]["TableName"]
+        == "VisionCommon.testing.dynamo.table.v00"
+    )

--- a/tests/xoto3/dynamodb/write_versioned/transact/run_test.py
+++ b/tests/xoto3/dynamodb/write_versioned/transact/run_test.py
@@ -204,23 +204,25 @@ def test_lazy_loading_reads_and_writes(
     integration_test_id_table_cleaner(dict(id=test_dest_id))
 
     def lazy_op(tx: VersionedTransaction) -> VersionedTransaction:
-        src = require(tx, tname, dict(id=test_id_source))
+        src = require(tx, "TEST", dict(id=test_id_source))
         if src["val"] > 5:
             # the if statement here is just an example of why you might want to lazy-load something.
             # In our test, this statement always passes because of the fixture data.
-            lazy = require(tx, tname, dict(id=test_id_lazy))
+            lazy = require(tx, "TEST", dict(id=test_id_lazy))
             print(lazy)
             dest_item = dict(id=test_dest_id, val=src["val"] + lazy["val"])
             print(dest_item)
-            return put(tx, tname, dest_item)
+            return put(tx, "TEST", dest_item)
         # this part of the test is just an example of what you might otherwise do.
         # it's not actually ever going to run in our test.
         return tx
 
     # note that we only specify upfront a key for the single item we know we need to prefetch
-    result = versioned_transact_write_items(lazy_op, {tname: [dict(id=test_id_source)]},)
+    result = versioned_transact_write_items(
+        lazy_op, dict(TEST=[dict(id=test_id_source)]), dict(TEST=tname)
+    )
 
-    assert require(result, tname, dict(id=test_dest_id)) == dict(id=test_dest_id, val=19)
+    assert require(result, "TEST", dict(id=test_dest_id)) == dict(id=test_dest_id, val=19)
 
 
 def test_optimistic_delete_nonexistent(integration_test_id_table):

--- a/xoto3/__about__.py
+++ b/xoto3/__about__.py
@@ -1,4 +1,4 @@
 """xoto3"""
-__version__ = "1.10.1"
+__version__ = "1.11.0"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"

--- a/xoto3/dynamodb/write_versioned/ddb_api.py
+++ b/xoto3/dynamodb/write_versioned/ddb_api.py
@@ -140,6 +140,7 @@ def built_transaction_to_transact_write_items_args(
     ClientRequestToken: str = "",
     item_version_attribute: str = "item_version",
     last_written_attribute: str = "last_written_at",
+    table_name_map: Mapping[str, str] = dict(),
 ) -> dict:
 
     args: Dict[str, Any] = dict(ClientRequestToken=ClientRequestToken)
@@ -147,6 +148,7 @@ def built_transaction_to_transact_write_items_args(
         args.pop("ClientRequestToken")
     transact_items = list()
     for table_name, tbl_data in transaction.tables.items():
+        table_name = table_name_map.get(table_name, table_name)
         items, effects, key_attributes = tbl_data
 
         def get_existing_item(hashable_key) -> dict:

--- a/xoto3/dynamodb/write_versioned/run.py
+++ b/xoto3/dynamodb/write_versioned/run.py
@@ -62,6 +62,7 @@ def _lazy_loading_transaction_builder(
 def versioned_transact_write_items(
     transaction_builder: TransactionBuilder,
     item_keys_by_table_name: Mapping[str, Collection[ItemKey]] = dict(),
+    table_name_map: Mapping[str, str] = dict(),
     *,
     batch_get_item: Optional[BatchGetItem] = None,
     transact_write_items: Optional[TransactWriteItems] = None,
@@ -119,6 +120,7 @@ def versioned_transact_write_items(
                     "",
                     item_version_attribute,
                     last_written_attribute,
+                    table_name_map,
                 )
             )
             return built_transaction


### PR DESCRIPTION
Allowing the transaction to use a different name for the table being
acted upon than the actual name that will be used when the transaction
is committed allows for easier unit testing of functions that act only
on a VersionedTransaction.