### PR TITLE
fix: versioned updates should also be resilient to concurrent transactions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### 1.10.2
+
+- Fixed `versioned_diffed_update_item` to support concurrent use with
+  transactions.
+
 ### 1.10.1
 
 - Fixed bug in `versioned_transact_write_items` where un-effected

--- a/xoto3/__about__.py
+++ b/xoto3/__about__.py
@@ -1,4 +1,4 @@
 """xoto3"""
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"

--- a/xoto3/dynamodb/write_versioned/ddb_api.py
+++ b/xoto3/dynamodb/write_versioned/ddb_api.py
@@ -9,7 +9,6 @@ from botocore.exceptions import ClientError
 from typing_extensions import Protocol, TypedDict
 
 from xoto3.dynamodb.types import Item
-from xoto3.dynamodb.update.versioned import versioned_item_expression
 from xoto3.dynamodb.utils.serde import serialize_item
 from xoto3.dynamodb.utils.table import table_primary_keys
 from xoto3.errors import client_error_name
@@ -132,6 +131,36 @@ def boto3_impl_defaults(
 
 def _serialize_versioned_expr(expr: dict) -> dict:
     return dict(expr, ExpressionAttributeValues=serialize_item(expr["ExpressionAttributeValues"]))
+
+
+# this could be used in a put_item scenario as well, or even with a batch_writer
+def versioned_item_expression(
+    item_version: int, item_version_key: str = "item_version", id_that_exists: str = ""
+) -> dict:
+    """Assembles a DynamoDB ConditionExpression with ExprAttrNames and
+    Values that will ensure that you are the only caller of
+    versioned_item_diffed_update that has updated this item.
+
+    In general it would be a silly thing to not pass id_that_exists if
+    your item_version is not also 0.  However, since this is just a
+    helper function and is only used (currently) by the local consumer
+    versioned_item_diffed_update, there is no need to enforce this.
+
+    """
+    expr_names = {"#itemVersion": item_version_key}
+    expr_vals = {":curItemVersion": item_version}
+    item_version_condition = "#itemVersion = :curItemVersion"
+    first_time_version_condition = "attribute_not_exists(#itemVersion)"
+    if id_that_exists:
+        expr_names["#idThatExists"] = id_that_exists
+        first_time_version_condition = (
+            f"( {first_time_version_condition} AND attribute_exists(#idThatExists) )"
+        )
+    return dict(
+        ExpressionAttributeNames=expr_names,
+        ExpressionAttributeValues=expr_vals,
+        ConditionExpression=item_version_condition + " OR " + first_time_version_condition,
+    )
 
 
 def built_transaction_to_transact_write_items_args(


### PR DESCRIPTION
Somehow we've never run into this before, but an ongoing TransactWriteItems request will cause a simple UpdateItem to fail, and we want to retry those within `versioned_diffed_update_item`.

this is a race condition so it's very hard to positively test, but you can check that the regression tests pass by following the testing instructions https://github.com/xoeye/xoto3#testing
