### PR TITLE
feat: stack-based context to prevent parameter drilling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.14.0
+
+`StackContext` and `OnCallDefault` utilities for providing new ways of
+injecting keyword arguments across a call stack without polluting all
+your function signatures in between.
+
 ### 1.13.1
 
 Fix regression in `backoff` and associated implementation.

--- a/tests/xoto3/dynamodb/get_test.py
+++ b/tests/xoto3/dynamodb/get_test.py
@@ -5,6 +5,7 @@ import pytest
 from xoto3.dynamodb.exceptions import ItemNotFoundException, get_item_exception_type
 from xoto3.dynamodb.get import (
     GetItem,
+    GetItem_kwargs,
     retry_notfound_consistent_read,
     strongly_consistent_get_item,
     strongly_consistent_get_item_if_exists,
@@ -86,3 +87,13 @@ def test_dont_retry_get_with_consistent_read_if_it_was_already_consistent():
         test_get(ConsistentRead=True)
 
     assert calls == 1
+
+
+def test_consistent_read_via_kwargs(integration_test_id_table, integration_test_id_table_put):
+    item_key = dict(id="item-will-not-immediately-exist")
+    item = dict(item_key, val="felicity")
+
+    integration_test_id_table_put(item)
+
+    with GetItem_kwargs.set_default(dict(ConsistentRead=True)):
+        assert item == GetItem(integration_test_id_table, item_key)

--- a/tests/xoto3/utils/contextual_default.py
+++ b/tests/xoto3/utils/contextual_default.py
@@ -13,3 +13,7 @@ def test_that_the_name_is_used_and_everything_works():
         assert f("b") == 4
         with IntDefault.set_default(7):
             assert f("c") == 7
+            assert f("c", 8) == 8
+        assert f("d") == 4
+    assert f("e") == 1
+    assert f("f", i=3) == 3

--- a/tests/xoto3/utils/contextual_default.py
+++ b/tests/xoto3/utils/contextual_default.py
@@ -1,0 +1,15 @@
+from xoto3.utils.contextual_default import ContextualDefault
+
+IntDefault = ContextualDefault("i", 1)
+
+
+def test_that_the_name_is_used_and_everything_works():
+    @IntDefault.apply
+    def f(a: str, i: int = 2):
+        return i
+
+    assert f("a") == 1
+    with IntDefault.set_default(4):
+        assert f("b") == 4
+        with IntDefault.set_default(7):
+            assert f("c") == 7

--- a/tests/xoto3/utils/oncall_default_test.py
+++ b/tests/xoto3/utils/oncall_default_test.py
@@ -9,7 +9,7 @@ utcnow = OnCallDefault(datetime.utcnow)
 
 
 def test_oncall_default_works_with_pos_or_kw():
-    @utcnow.default("when")
+    @utcnow.apply_to("when")
     def final(a: str, when: datetime = utcnow(), f: float = 1.2):
         return when
 
@@ -21,7 +21,7 @@ def test_oncall_default_works_with_pos_or_kw():
 
 
 def test_oncall_default_works_with_kw_only():
-    @utcnow.default("when")
+    @utcnow.apply_to("when")
     def f(a: str, *, when: datetime = utcnow()):
         return when
 
@@ -30,7 +30,7 @@ def test_oncall_default_works_with_kw_only():
 
 
 def test_deco_works_with_var_kwargs():
-    @utcnow.default("when")
+    @utcnow.apply_to("when")
     def f(**kwargs):
         return kwargs["when"]
 
@@ -49,7 +49,7 @@ def test_disallow_positional_without_default():
 
     with pytest.raises(NotSafeToDefaultError):
 
-        @utcnow.default("when")
+        @utcnow.apply_to("when")
         def nope(when: datetime, a: int):
             pass
 
@@ -58,7 +58,7 @@ def test_disallow_not_found_without_var_kwargs():
 
     with pytest.raises(NotSafeToDefaultError):
 
-        @utcnow.default("notthere")
+        @utcnow.apply_to("notthere")
         def steve(a: str, *args, b=1, c=2):
             pass
 
@@ -68,7 +68,7 @@ def test_disallow_var_args_name_matches():
         # *args itself has the default value 'new empty tuple', and if
         # you want to provide a positional default you should give it
         # a real name.
-        @utcnow.default("args")
+        @utcnow.apply_to("args")
         def felicity(a: str, *args):
             pass
 
@@ -77,6 +77,6 @@ def test_disallow_var_args_name_matches():
         # kwargs itself has the default value 'new empty dict', and if
         # you want to put things in it you should specify them
         # individually.
-        @utcnow.default("kwargs")
+        @utcnow.apply_to("kwargs")
         def george(a: str, **kwargs):
             pass

--- a/tests/xoto3/utils/oncall_default_test.py
+++ b/tests/xoto3/utils/oncall_default_test.py
@@ -1,0 +1,82 @@
+# pylint: disable=unused-argument,unused-variable
+from datetime import datetime
+
+import pytest
+
+from xoto3.utils.oncall_default import NotSafeToDefaultError, OnCallDefault
+
+utcnow = OnCallDefault(datetime.utcnow)
+
+
+def test_oncall_default_works_with_pos_or_kw():
+    @utcnow.default("when")
+    def final(a: str, when: datetime = utcnow(), f: float = 1.2):
+        return when
+
+    assert final("a") <= utcnow()
+
+    val = datetime(1888, 8, 8, 8, 8, 8)
+    assert val == final("a", when=val)
+    assert val == final("c", f=4.2, when=val)
+
+
+def test_oncall_default_works_with_kw_only():
+    @utcnow.default("when")
+    def f(a: str, *, when: datetime = utcnow()):
+        return when
+
+    val = datetime(1900, 1, 1, 11, 11, 11)
+    assert val == f("3", when=val)
+
+
+def test_deco_works_with_var_kwargs():
+    @utcnow.default("when")
+    def f(**kwargs):
+        return kwargs["when"]
+
+    assert datetime.utcnow() <= f()
+    assert f() <= datetime.utcnow()
+
+    direct = datetime(2012, 12, 12, 12, 12, 12)
+    assert direct == f(when=direct)
+
+
+def test_disallow_positional_without_default():
+    """A positional-possible argument without a default could have a
+    positional argument provided after it and then we'd be unable to tell
+    for sure whether it had been provided intentionally.
+    """
+
+    with pytest.raises(NotSafeToDefaultError):
+
+        @utcnow.default("when")
+        def nope(when: datetime, a: int):
+            pass
+
+
+def test_disallow_not_found_without_var_kwargs():
+
+    with pytest.raises(NotSafeToDefaultError):
+
+        @utcnow.default("notthere")
+        def steve(a: str, *args, b=1, c=2):
+            pass
+
+
+def test_disallow_var_args_name_matches():
+    with pytest.raises(NotSafeToDefaultError):
+        # *args itself has the default value 'new empty tuple', and if
+        # you want to provide a positional default you should give it
+        # a real name.
+        @utcnow.default("args")
+        def felicity(a: str, *args):
+            pass
+
+    with pytest.raises(NotSafeToDefaultError):
+
+        # kwargs itself has the default value 'new empty dict', and if
+        # you want to put things in it you should specify them
+        # individually.
+        @utcnow.default("kwargs")
+        def george(a: str, **kwargs):
+            pass

--- a/tests/xoto3/utils/oncall_default_test.py
+++ b/tests/xoto3/utils/oncall_default_test.py
@@ -72,11 +72,19 @@ def test_disallow_var_args_name_matches():
         def felicity(a: str, *args):
             pass
 
-    with pytest.raises(NotSafeToDefaultError):
 
-        # kwargs itself has the default value 'new empty dict', and if
-        # you want to put things in it you should specify them
-        # individually.
-        @utcnow.apply_to("kwargs")
-        def george(a: str, **kwargs):
-            pass
+GeorgeKwargs = OnCallDefault(lambda: dict(b=2, c=3))
+
+
+def test_allow_var_kwargs_merge():
+    # kwargs itself is a dict,
+    # and we will perform top-level merging
+    # for you if that's what you want
+
+    @GeorgeKwargs.apply_to("kwargs")
+    def george(a: str, **kwargs):
+        return kwargs
+
+    assert george("1") == dict(b=2, c=3)
+    assert george("2", b=3) == dict(b=3, c=3)
+    assert george("3", c=5, d=78) == dict(b=2, c=5, d=78)

--- a/tests/xoto3/utils/stack_context_test.py
+++ b/tests/xoto3/utils/stack_context_test.py
@@ -1,0 +1,69 @@
+from contextvars import ContextVar
+from datetime import datetime
+
+from xoto3.utils.oncall_default import OnCallDefault
+from xoto3.utils.stack_context import StackContext, stack_context, unwrap
+
+NowContext = ContextVar("UtcNow", default=datetime.utcnow)
+
+
+def test_stack_context():
+    def final():
+        return NowContext.get()()
+
+    def intermediate():
+        return final()
+
+    outer_when = datetime(2018, 9, 9, 9, 9, 9)
+
+    def outer():
+        with stack_context(NowContext, lambda: outer_when):
+            return intermediate()
+
+    way_outer_when = datetime(2019, 12, 12, 8, 0, 0)
+    with stack_context(NowContext, lambda: way_outer_when):
+        assert way_outer_when == intermediate()
+        assert outer_when == outer()
+
+    assert NowContext.get() != outer_when
+    assert NowContext.get() != way_outer_when
+
+
+def test_composes_with_oncall_default():
+
+    when = OnCallDefault(unwrap(NowContext.get))
+
+    @when.default("now")
+    def f(now: datetime = when()):
+        assert isinstance(now, datetime)
+        return now
+
+    val = datetime(1922, 8, 3, 1, 2, 1)
+    assert f(now=val) == val
+
+    with stack_context(NowContext, lambda: val):
+        assert val == f()
+        new_val = datetime(888, 8, 8, 8, 8, 8)
+        with stack_context(NowContext, lambda: new_val):
+            assert new_val == f()
+        assert val == f()
+        assert new_val == f(new_val)
+
+    assert f(val) == val
+    assert f(val) <= datetime.utcnow()
+
+
+ConsistentReadContext = StackContext("ConsistentRead", False)
+
+
+def test_StackContext_interface():
+    def f():
+        return ConsistentReadContext()
+
+    def g():
+        return f()
+
+    assert g() is False
+    with ConsistentReadContext.set(True):
+        assert g() is True
+    assert g() is False

--- a/tests/xoto3/utils/stack_context_test.py
+++ b/tests/xoto3/utils/stack_context_test.py
@@ -33,7 +33,7 @@ def test_composes_with_oncall_default():
 
     when = OnCallDefault(unwrap(NowContext.get))
 
-    @when.default("now")
+    @when.apply_to("now")
     def f(now: datetime = when()):
         assert isinstance(now, datetime)
         return now

--- a/xoto3/__about__.py
+++ b/xoto3/__about__.py
@@ -1,4 +1,4 @@
 """xoto3"""
-__version__ = "1.13.1"
+__version__ = "1.14.0"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"

--- a/xoto3/dynamodb/get.py
+++ b/xoto3/dynamodb/get.py
@@ -11,22 +11,18 @@ from .types import Item, ItemKey, TableResource
 logger = getLogger(__name__)
 
 
-GetItemConsistentRead = ContextualDefault("ConsistentRead", False, "xoto3-GetItem-")
+GetItemKwargs: ContextualDefault[dict] = ContextualDefault("get_item_kwargs", dict(), "xoto3-")
 
 
-@GetItemConsistentRead.apply
+@GetItemKwargs.apply
 def GetItem(
-    Table: TableResource,
-    Key: ItemKey,
-    nicename=DEFAULT_ITEM_NAME,
-    ConsistentRead: bool = GetItemConsistentRead(),
-    **kwargs,
+    Table: TableResource, Key: ItemKey, nicename=DEFAULT_ITEM_NAME, **get_item_kwargs,
 ) -> Item:
     """Use this instead of get_item to raise
     {nicename/Item}NotFoundException when an item is not found.
 
     ```
-    with GetItemConsistentRead.set_default(True):
+    with GetItemKwargs.set_default(dict(ConsistentRead=True)):
         function_that_calls_GetItem(...)
     ```
 
@@ -37,7 +33,7 @@ def GetItem(
     """
     nicename = nicename or DEFAULT_ITEM_NAME  # don't allow empty string
     logger.debug(f"Get{nicename} {Key} from Table {Table.name}")
-    response = Table.get_item(Key={**Key}, **kwargs)
+    response = Table.get_item(Key={**Key}, **get_item_kwargs)
     raise_if_empty_getitem_response(response, nicename=nicename, key=Key, table_name=Table.name)
     return response["Item"]
 

--- a/xoto3/dynamodb/get.py
+++ b/xoto3/dynamodb/get.py
@@ -2,6 +2,8 @@ from functools import wraps
 from logging import getLogger
 from typing import Callable, TypeVar, cast
 
+from xoto3.utils.stack_default import StackDefault
+
 from .constants import DEFAULT_ITEM_NAME
 from .exceptions import ItemNotFoundException, raise_if_empty_getitem_response
 from .types import Item, ItemKey, TableResource
@@ -9,7 +11,17 @@ from .types import Item, ItemKey, TableResource
 logger = getLogger(__name__)
 
 
-def GetItem(Table: TableResource, Key: ItemKey, nicename=DEFAULT_ITEM_NAME, **kwargs) -> Item:
+ConsistentRead = StackDefault("xoto3-GetItem-ConsistentRead", False)
+
+
+@ConsistentRead.apply_to("ConsistentRead")
+def GetItem(
+    Table: TableResource,
+    Key: ItemKey,
+    nicename=DEFAULT_ITEM_NAME,
+    ConsistentRead: bool = ConsistentRead(),
+    **kwargs,
+) -> Item:
     """Use this if possible instead of get_item directly
 
     because the default behavior of the boto3 get_item is bad (doesn't

--- a/xoto3/dynamodb/get.py
+++ b/xoto3/dynamodb/get.py
@@ -11,10 +11,10 @@ from .types import Item, ItemKey, TableResource
 logger = getLogger(__name__)
 
 
-GetItemKwargs: ContextualDefault[dict] = ContextualDefault("get_item_kwargs", dict(), "xoto3-")
+GetItem_kwargs: ContextualDefault[dict] = ContextualDefault("get_item_kwargs", dict(), "xoto3-")
 
 
-@GetItemKwargs.apply
+@GetItem_kwargs.apply
 def GetItem(
     Table: TableResource, Key: ItemKey, nicename=DEFAULT_ITEM_NAME, **get_item_kwargs,
 ) -> Item:

--- a/xoto3/dynamodb/get.py
+++ b/xoto3/dynamodb/get.py
@@ -22,7 +22,7 @@ def GetItem(
     {nicename/Item}NotFoundException when an item is not found.
 
     ```
-    with GetItemKwargs.set_default(dict(ConsistentRead=True)):
+    with GetItem_kwargs.set_default(dict(ConsistentRead=True)):
         function_that_calls_GetItem(...)
     ```
 

--- a/xoto3/utils/contextual_default.py
+++ b/xoto3/utils/contextual_default.py
@@ -1,0 +1,29 @@
+import typing as ty
+
+from .oncall_default import F, OnCallDefault, T
+from .stack_context import StackContext
+
+
+class ContextualDefault(ty.Generic[T]):
+    """A shortcut for implementing simple StackContexts that are used only
+    for OnCallDefaults on a particular function.
+
+    Though this _can_ be shared across functions, the parameter name
+    will have to be identical, and you should consider having separate
+    ContextVars per function for sanity. If your functions are truly
+    logically grouped, it might make more sense to write a class.
+    """
+
+    def __init__(self, param_name: str, default: T, context_prefix: str = ""):
+        self.param_name = param_name
+        self.stack_context = StackContext(context_prefix + param_name, default)
+        self.oncall_default = OnCallDefault(self.stack_context)
+
+    def __call__(self) -> T:
+        return self.stack_context()
+
+    def apply(self, f: F) -> F:
+        return self.oncall_default.apply_to(self.param_name)(f)
+
+    def set_default(self, default_value: T):
+        return self.stack_context.set(default_value)

--- a/xoto3/utils/dt.py
+++ b/xoto3/utils/dt.py
@@ -7,7 +7,8 @@ It's a shame this isn't in the core language.
 """
 from datetime import datetime, timezone
 
-_UTC_TZ_HRS = "+00:00"
+_UTC_TZ_OFFSET = "+00:00"
+_UTC_Z = "Z"
 
 
 def iso8601strict(dt: datetime) -> str:
@@ -18,4 +19,14 @@ def iso8601strict(dt: datetime) -> str:
     """
     if dt.tzinfo:
         dt = dt.astimezone(timezone.utc)
-    return dt.isoformat(timespec="microseconds").replace(_UTC_TZ_HRS, "") + "Z"
+    return dt.isoformat(timespec="microseconds").replace(_UTC_TZ_OFFSET, "") + _UTC_Z
+
+
+def parse8601strict(dt_s: str, aware: bool = False) -> datetime:
+    """Returns a datetime from the string format defined above"""
+    if dt_s.endswith("Z"):
+        dt_s = dt_s.replace(_UTC_Z, _UTC_TZ_OFFSET)
+    val = datetime.strptime(dt_s, "%Y-%m-%dT%H:%M:%S.%f%z")
+    if not aware:
+        return val.replace(tzinfo=None)
+    return val

--- a/xoto3/utils/oncall_default.py
+++ b/xoto3/utils/oncall_default.py
@@ -164,7 +164,7 @@ class OnCallDefault(ty.Generic[T]):
     def __init__(self, default_callable: ty.Callable[[], T]):
         self.default_callable = default_callable
 
-    def default(self, param_name: str) -> ty.Callable[[F], F]:
+    def apply_to(self, param_name: str) -> ty.Callable[[F], F]:
         return make_oncall_default_deco(self.default_callable, param_name)
 
     def __call__(self) -> T:

--- a/xoto3/utils/oncall_default.py
+++ b/xoto3/utils/oncall_default.py
@@ -1,0 +1,172 @@
+"""A mechanism for providing less-verbose dynamic defaults for functions"""
+
+import inspect
+import typing as ty
+from functools import wraps
+
+F = ty.TypeVar("F", bound=ty.Callable)
+T = ty.TypeVar("T")
+
+
+class NotSafeToDefaultError(ValueError):
+    """A positional parameter without a default is not safe to provide a
+    default for, because it is not logical for a caller to expect not
+    to have to provide an argument, and if there is more than one
+    positional argument provided by the caller at runtime, it will be
+    impossible for us to know which one the caller actually meant to
+    provide, leading to ambiguous errors.
+
+    A keyword-only argument without a default is allowed only because
+    the callers will always have to specify it by name. In practice,
+    it's a bad idea to apply dynamic defaults to a keyword argument
+    with no default, because it will look very confusing to IDEs, type
+    checkers, etc.
+
+    A function with a var-kwargs collector (**kw) will also be allowed
+    if the parameter name is not found in the function signature. That
+    dictionary will always have your default populated unless the
+    caller supplied one.
+
+    Any other type of argument is not dynamically defaultable and this
+    error will be raised.
+
+    """
+
+
+def _validate_argument_is_defaultable(f: F, param_name: str) -> float:
+    """Returns float infinity if the parameter is keyword-only, and
+    returns the parameter position if the argument can be supplied
+    positionally but a default is defined, meaning that it is past the
+    positional arguments that don't have a default, which means that a
+    caller not supplying this argument will also not be supplying any
+    other positional arguments positionally.
+
+    """
+    sig = inspect.signature(f)
+    has_var_kwargs = False
+    for i, param in enumerate(sig.parameters.values()):
+        if param.name == param_name:
+            if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
+                if param.default is inspect.Parameter.empty:
+                    raise NotSafeToDefaultError(
+                        f"Positional function parameter {param_name} must have a default "
+                        "to be eligible for having an oncall default provided."
+                    )
+                return i
+            if param.kind == inspect.Parameter.KEYWORD_ONLY:
+                # if it can only be supplied by keyword, then it is
+                # always simple to identify whether the caller
+                # provided it.
+                return float("inf")
+            raise NotSafeToDefaultError(
+                f"Cannot create a decorated function where {param_name} "
+                "is present but not one of the matched types"
+            )
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            has_var_kwargs = True
+    # the argument was not found by name. If var kwargs were defined,
+    # then we simply provide a default that way. Otherwise, this cannot work
+    if has_var_kwargs:
+        return float("inf")
+    raise NotSafeToDefaultError(
+        f"Could not find function parameter {param_name} "
+        "and there is no variable keyword arguments parameter defined"
+    )
+
+
+def make_oncall_default_deco(
+    default_callable: ty.Callable[[], T], param_name: str
+) -> ty.Callable[[F], F]:
+    def oncall_default_param_decorator(f: F) -> F:
+        pos_num = _validate_argument_is_defaultable(f, param_name)
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            if param_name not in kwargs:
+                # if it was provided as a keyword argument, then there's nothing for us to do
+                if len(args) <= pos_num:
+                    # the argument is keyword-only or was not provided as a positional argument
+                    kwargs[param_name] = default_callable()
+            return f(*args, **kwargs)
+
+        return ty.cast(F, wrapper)
+
+    return oncall_default_param_decorator
+
+
+class OnCallDefault(ty.Generic[T]):
+    """Creates a partially-applied decorator to specify that you want a
+    oncall default value for a safely-defaultable function parameter.
+
+    Python's default behavior is to define a static default when the
+    function is defined.  In some cases, this is not at all what you
+    want - for instance, you might want an empty, mutable list every
+    time the function is called, but Python will not allow you to
+    define that. The decorator created here will allow you to specify
+    what callable you want to use to create your default, and will
+    inject its result into every function call where no value has been
+    provided by the caller.
+
+    This only works for certain cases:
+
+    1. Keyword-only parameters, preferably with a defined default.
+
+    2. Arguments provided to the function via var-kwargs (**kwargs) capture.
+
+    3. Positional-or-keyword parameters where a default is explicitly
+       provided in the function definition.
+
+    This is because it is not possible to identify which arguments a
+    caller unaware of the special oncall default behavior _did not_
+    intend to provide solely by their position. By preserving this
+    restriction, we allow callers to remain blissfully ignorant of the
+    application of this decorator.
+
+    PLEASE NOTE: It is strongly recommended that you use this only for
+    keyword-only arguments that your function does not require to be
+    provided. In other words, when someone reads your function
+    signature without the decorator, they should be able to understand
+    in what ways your function will be callable.  Usage with
+    positional arguments in functions with complex signatures should
+    be conisdered borderline sociopathic even if it works.
+
+    ```
+    utcnow = OnCallDefault(datetime.utcnow)
+
+    @utcnow.default('updated_at')
+    def do_the_thing(entity: E, new_bar: Bar, *, updated_at: datetime) -> E:
+        entity.bar = new_bar
+        entity.updated_at = updated_at
+        return entity
+    ```
+
+    then call as:
+
+    `do_the_thing(my_entity, new_bar)`
+
+    And let this wrapper fill in the current value from the OnCallDefault.
+
+    If you want IDEs and type checkers to be happy with the call, you
+    should also define an unused standard default - its value will
+    never get used as long as the decorator is applied. This class
+    provides a simply callable syntax for providing a typed default
+    that the Python runtime and standard utilities will be able to
+    intepret just fine.
+
+    ```
+    @utcnow.default('updated_at')
+    def do_the_thing(entity: E, new_bar: Bar, updated_at: datetime = utcnow()) -> E:
+        ...
+    ```
+
+    """
+
+    def __init__(self, default_callable: ty.Callable[[], T]):
+        self.default_callable = default_callable
+
+    def default(self, param_name: str) -> ty.Callable[[F], F]:
+        return make_oncall_default_deco(self.default_callable, param_name)
+
+    def __call__(self) -> T:
+        """Returns the value of the callable. A convenience for defining your default"""
+        return self.default_callable()

--- a/xoto3/utils/oncall_default.py
+++ b/xoto3/utils/oncall_default.py
@@ -126,11 +126,15 @@ class OnCallDefault(ty.Generic[T]):
     3. Positional-or-keyword parameters where a default is explicitly
        provided in the function definition.
 
-    This is because it is not possible to identify which arguments a
-    caller unaware of the special oncall default behavior _did not_
-    intend to provide solely by their position. By preserving this
-    restriction, we allow callers to remain blissfully ignorant of the
-    application of this decorator.
+    4. The full **kwargs dictionary. This is a special case where we
+       will take your provided default dictionary and then perform a
+       shallow merge of the provided keyword arguments.
+
+    The limitations are because it is not otherwise possible to
+    identify which arguments a caller unaware of the special oncall
+    default behavior _did not_ intend to provide solely by their
+    position. By preserving this restriction, we allow callers to
+    remain blissfully ignorant of the application of this decorator.
 
     PLEASE NOTE: It is strongly recommended that you use this only for
     keyword-only arguments that your function does not require to be

--- a/xoto3/utils/stack_context.py
+++ b/xoto3/utils/stack_context.py
@@ -42,6 +42,10 @@ def stack_context(contextvar: cv.ContextVar[T], value: T) -> ty.Iterator:
 class StackContext(ty.Generic[T]):
     """A thin wrapper around a ContextVar that keeps other users from
     setting it directly.
+
+    These should only be created at a module level, just like the
+    underlying ContextVar.
+
     """
 
     def __init__(self, name: str, default: T):

--- a/xoto3/utils/stack_context.py
+++ b/xoto3/utils/stack_context.py
@@ -1,0 +1,77 @@
+import contextlib as cl
+import contextvars as cv
+import typing as ty
+
+T = ty.TypeVar("T")
+F = ty.TypeVar("F", bound=ty.Callable)
+
+
+@cl.contextmanager
+def stack_context(contextvar: cv.ContextVar[T], value: T) -> ty.Iterator:
+    """Provide context down the stack without 'parameter drilling'.
+
+    A ContextManager for the value of a ContextVar.
+
+    Sometimes you need to be able to push arguments through layers of
+    function calls without polluting the signature of every function
+    in between. We all know globals are a bad idea, the DX of thread
+    locals is not much better, and doesn't work with async code. This
+    uses ContextVar under the hood (to be compatible with async) and
+    also makes what you're doing a lot more explicit.
+
+    Caveat emptor: This is essentially functional dependency
+    injection. Like all forms of dependency injection, it creates
+    spooky action at a distance. The advantage is that you can reduce
+    explicit coupling. The disadvantage is that the coupling becomes
+    harder to immediately see.
+
+    In some cases it would be better for your code to make its
+    dependencies explicit by going ahead and doing prop-drilling, so
+    don't use this just because you can. In many cases, a functional
+    core, imperative shell approach will be clearer. This is for cases
+    where the benefits of the magic clearly outweigh its harms. Choose
+    wisely.
+    """
+    try:
+        token = contextvar.set(value)
+        yield
+    finally:
+        contextvar.reset(token)
+
+
+class StackContext(ty.Generic[T]):
+    """A thin wrapper around a ContextVar that keeps other users from
+    setting it directly.
+    """
+
+    def __init__(self, name: str, default: T):
+        self._contextvar = cv.ContextVar(name, default=default)
+
+    def set(self, value: T) -> ty.ContextManager[T]:
+        return stack_context(self._contextvar, value)
+
+    def get(self) -> T:
+        return self._contextvar.get()
+
+    def __call__(self) -> T:
+        """4 fewer characters than .get()"""
+        return self.get()
+
+
+def unwrap(callable: ty.Callable[[], ty.Callable[[], T]], *, layers: int = 1) -> ty.Callable[[], T]:
+    """It's pretty common to want to provide a Callable that
+    requires no arguments and returns a value, e.g. so that your
+    default value can be lazily loaded.
+
+    This just gives you a way of saying that you always want the
+    wrapped value whenever you call the outer callable.
+
+    """
+
+    def unwrapping() -> T:
+        c = callable
+        for i in range(layers):
+            c = c()  # type: ignore
+        return c()  # type: ignore
+
+    return unwrapping

--- a/xoto3/utils/stack_context.py
+++ b/xoto3/utils/stack_context.py
@@ -21,16 +21,18 @@ def stack_context(contextvar: cv.ContextVar[T], value: T) -> ty.Iterator:
 
     Caveat emptor: This is essentially functional dependency
     injection. Like all forms of dependency injection, it creates
-    spooky action at a distance. The advantage is that you can reduce
-    explicit coupling. The disadvantage is that the coupling becomes
-    harder to immediately see.
+    action at a distance. The advantage is that you can reduce
+    coupling in intermediate layers. The disadvantage is that even
+    though this is more explicit than globals, it's still less
+    explicit than parameter drilling.
 
-    In some cases it would be better for your code to make its
+    So, In some cases it may be better for your code to make its
     dependencies explicit by going ahead and doing prop-drilling, so
     don't use this just because you can. In many cases, a functional
     core, imperative shell approach will be clearer. This is for cases
     where the benefits of the magic clearly outweigh its harms. Choose
     wisely.
+
     """
     try:
         token = contextvar.set(value)
@@ -40,8 +42,8 @@ def stack_context(contextvar: cv.ContextVar[T], value: T) -> ty.Iterator:
 
 
 class StackContext(ty.Generic[T]):
-    """A thin wrapper around a ContextVar that keeps other users from
-    setting it directly.
+    """A thin wrapper around a ContextVar that requires it to be set in a
+    stack-frame limited manner.
 
     These should only be created at a module level, just like the
     underlying ContextVar.


### PR DESCRIPTION
use ContextualDefault to essentially inject dependencies across contexts, the way you would do if a function wrapping some IO were a configurable OO client that got passed all the way down.

It's still preferable to use functional-core, imperative shell approaches, but this will solve some problems in a pinch.

