### PR TITLE
feat: most generic single item writer for write_versioned API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.16.0
+
+- `write_item` single item write helper for the `write_versioned`
+  higher level DynamoDB transaction API. Suitable for any form of
+  transactional write to a single item (creation/update/deletion).
+
 ### 1.15.1
 
 Fixes to `versioned_transact_write_items`:

--- a/xoto3/__about__.py
+++ b/xoto3/__about__.py
@@ -1,4 +1,4 @@
 """xoto3"""
-__version__ = "1.15.1"
+__version__ = "1.16.0"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"

--- a/xoto3/dynamodb/write_versioned/__init__.py
+++ b/xoto3/dynamodb/write_versioned/__init__.py
@@ -4,7 +4,14 @@ Anything you import from any underlying module directly (i.e. not from
 here) is not guaranteed to remain, so don't do that. Import this
 module and use only what it exposes.
 """
-from .api2 import ItemTable, TypedTable, create_or_update, update_existing, update_if_exists  # noqa
+from .api2 import (  # noqa
+    ItemTable,
+    TypedTable,
+    create_or_update,
+    update_existing,
+    update_if_exists,
+    write_item,
+)
 from .errors import (  # noqa
     ItemUndefinedException,
     TableSchemaUnknownError,


### PR DESCRIPTION
Overall, I would say this should be used incredibly rarely at XOi. I have introduced it because I do have a specific case where I wanted to be able to fully unit test some existing hard-deletion code. And there would be other circumstances where we might theoretically want to do hard deletions. But in order of more narrow to more general, I'd order these 4 helpers:

```
update_existing
update_if_exists
create_or_update
write_item
```

And I would suggest users of this library always pick the narrowest one that is applicable to our situation. I think that makes our code simpler even if it's not as easy as just always picking the same helper off the tree.