### PR TITLE
Update xoto3.lam.finalize  for Python >3.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.16.1
+
+- Fix xoto3.lam.finalize for Python > 3.7
+
 ## 1.16.0
 
 - `write_item` single item write helper for the `write_versioned`

--- a/scripts/pylint_pipenv_score_limit.py
+++ b/scripts/pylint_pipenv_score_limit.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
 import argparse
 import os
-import sys
 import subprocess
-
-from pylint import lint
+import sys
 
 from pipenv_utils import get_pythonpath_for_pipfile_dir_and_venv
+from pylint import lint
 
 
 def module_passes_lint_score_limit(path, limit, other_args=()) -> bool:
     run = lint.Run([path, *other_args], do_exit=False)
-    score = run.linter.stats.get("global_note", -1.0)
+    score = run.linter.stats.global_note
 
     if score < limit:
         print(f"Score for {path} was {score:.03f}; less than limit {limit}")

--- a/xoto3/__about__.py
+++ b/xoto3/__about__.py
@@ -1,4 +1,4 @@
 """xoto3"""
-__version__ = "1.16.0"
+__version__ = "1.16.1"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"


### PR DESCRIPTION
Use `awslambdaric.__version__` rather than python version on > 3.7 to install post invocation hooks.

Testing steps:
1. Create a test lambda with Python 3.9
1. Create a `finalize.py` file in the root directory of your lambda using the web editor with the contents of `finalize.py` in this PR 
    - Remove the is_aws_env import
    - Remove the `if not is_aws_env()` block 
1. Edit handler.py and add the following:
    ```python
    from finalize import register_lambda_finalize_thunk
    register_lambda_finalize_thunk(lambda: print("Hook works!"))
    ```
1. Deploy the function and perform a test execution with any payload
1. Assert that `Hook works!` appears in the logs

**If that works**, change your Lambda's runtime to Python 3.7 and repeat the last two steps to confirm no regression
