### PR TITLE
VS-1487: fix: Threaded BatchGetItem on 3.8+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### 1.16.2
+
+- Switches `BatchGetItem`'s threadpool to `concurrent.futures.ThreadPoolExecutor`
+  to work in AWS Lambda environments running Python 3.8+
+- Adds `scripts/create_integration_test_table.py`; creates a DynamoDB table used
+  for running integration tests
+
 ### 1.16.1
 
 - Fix xoto3.lam.finalize for Python > 3.7

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ and no range key.
 `XOTO3_INTEGRATION_TEST_NO_RANGE_KEY_INDEX_HASH_KEY`: the name of an
 attribute which is the partition key of a GSI with no range key.
 
+If you don't currently have a table viable for testing, you can use the following script to easily create one:
+`pipenv run python ./scripts/create_integration_test_table.py`
+
 ## Development
 
 ### Writing tests

--- a/scripts/create_integration_test_table.py
+++ b/scripts/create_integration_test_table.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+import argparse
+import getpass
+import logging
+from time import sleep
+
+import boto3
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+ddb = boto3.client("dynamodb")
+
+PK_NAME = "id"
+GSI_NAME = "gsi_hash"
+
+
+def _table_exists(table_name: str) -> bool:
+    try:
+        ddb.describe_table(TableName=table_name)
+    except ddb.exceptions.ResourceNotFoundException:
+        return False
+
+    return True
+
+
+def main(table_name: str, recreate=False):
+    if _table_exists(table_name):
+        logger.info("Table %s already exists", table_name)
+        if recreate:
+            logger.info("Parameter --recreate passed, deleting table and re-creating...")
+            ddb.delete_table(TableName=table_name)
+            while True:
+                try:
+                    status = ddb.describe_table(TableName=table_name)["Table"]["TableStatus"]
+                    logger.info("Current table status: %s", status)
+                except ddb.exceptions.ResourceNotFoundException:
+                    logger.info("Table successfully deleted.")
+                    break
+                else:
+                    sleep(3)
+
+        else:
+            logger.warning("--recreate not passed. Keeping existing table, nothing left to do.")
+            return
+
+    logger.info("Creating table %s", table_name)
+    ddb.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[
+            {"AttributeName": PK_NAME, "AttributeType": "S"},
+            {"AttributeName": GSI_NAME, "AttributeType": "S"},
+        ],
+        KeySchema=[{"AttributeName": PK_NAME, "KeyType": "HASH"}],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": GSI_NAME,
+                "KeySchema": [{"AttributeName": GSI_NAME, "KeyType": "HASH"},],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    while True:
+        status = ddb.describe_table(TableName=table_name)["Table"]["TableStatus"]
+        if status == "ACTIVE":
+            logger.info("Finished table creation")
+            break
+        else:
+            logger.info("Awaiting table creation. Current status: '%s'", status)
+            sleep(3)
+
+    logger.info("Success!\n\n")
+    print("Paste the following lines into your terminal or add to your shell .rc file:\n")
+    print(f"export XOTO3_INTEGRATION_TEST_DYNAMODB_ID_TABLE_NAME='{table_name}'")
+    print(f"export XOTO3_INTEGRATION_TEST_NO_RANGE_KEY_INDEX_HASH_KEY='{GSI_NAME}'")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--table-suffix", default=getpass.getuser())
+    parser.add_argument("--recreate", action="store_const", const=True)
+
+    args = parser.parse_args()
+
+    _table_name = f"xoto3-integration-{args.table_suffix}"
+    main(_table_name, args.recreate)

--- a/xoto3/__about__.py
+++ b/xoto3/__about__.py
@@ -1,4 +1,4 @@
 """xoto3"""
-__version__ = "1.16.1"
+__version__ = "1.16.2"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"


### PR DESCRIPTION
`BatchGetItem` does not work in AWS Lambda on Python 3.8+ due to internal changes in the multiprocessing module.

This PR switches the threadpool implementation to `concurrent.futures.ThreadPoolExecutor`.

I have also gone ahead and created a simple script to ease creation and configuration of a DynamoDB table and environment variables used to run integration tests.