### PR TITLE
Loosen required python constraint

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,19 +11,14 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["python"]
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
-          languages: ${{ matrix.language }}
+          languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,17 +10,17 @@ env:
   AWS_SECRET_ACCESS_KEY: just_to_make_boto3_imports_work
 
 jobs:
-  unit-test:
+  mypy:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         # Quoted otherwise treated as a float literal (3.10 == 3.1)
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -30,4 +30,24 @@ jobs:
       - run: poetry install
 
       - run: poetry run mypy xoto3
+
+  unit-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Quoted otherwise treated as a float literal (3.10 == 3.1)
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install poetry
+      - run: poetry env use ${{ matrix.python-version }}
+      - run: poetry install
+
       - run: poetry run pytest tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### 2.0.1
+
+- Removed upper bound on python v3.11
+- Removed dead code in xoto3.lam.finalize for handling awslambdaric 1.x
+
 ### 2.0.0
 
 #### Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{ include = "xoto3" }]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.11"
+python = "^3.9"
 boto3 = ">=1.9"
 typing-extensions = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ typing-extensions = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.0"
-mypy = ">=1.15.0"
+mypy = "^1.15.0"
 pylint = "^2.7.0"
 pytest-cov = "*"
 pytest-xdist = "~=1.34"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ mypy = "^1.15.0"
 pylint = "^2.7.0"
 pytest-cov = "*"
 pytest-xdist = "~=1.34"
+awslambdaric = ">=2.0.0"
 
 [tool.poetry.requires-plugins]
 poetry-bumpversion = "^0.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xoto3"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Peter Gaultney <pgaultney@xoi.io>"]
 description = "High level utilities for a subset of boto3 operations common for AWS serverless development in Python."
 readme = "README.md"

--- a/xoto3/__about__.py
+++ b/xoto3/__about__.py
@@ -1,4 +1,4 @@
 """xoto3"""
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"

--- a/xoto3/lam/finalize.py
+++ b/xoto3/lam/finalize.py
@@ -65,34 +65,21 @@ def __setup_lambda_finalize_hook():
         return
 
     try:
-        aws_lambda_bootstrap = None
-        if sys.version_info[0] == 3 and sys.version_info[1] == 7:
-            import bootstrap as _aws_lambda_bootstrap  # pylint: disable=import-outside-toplevel,import-error
+        from awslambdaric import __version__  # pylint: disable=import-outside-toplevel
 
-            aws_lambda_bootstrap = _aws_lambda_bootstrap
-        else:
-            try:
-                from awslambdaric import __version__  # pylint: disable=import-outside-toplevel
+        if __version__.split(".")[0] in {"2", "3"}:
+            import awslambdaric.bootstrap as aws_lambda_bootstrap  # pylint: disable=import-outside-toplevel,import-error
 
-                if __version__.split(".")[0] in {"2", "3"}:
-                    import awslambdaric.bootstrap as _aws_lambda_bootstrap  # pylint: disable=import-outside-toplevel,import-error
-
-                    aws_lambda_bootstrap = _aws_lambda_bootstrap
-                else:
-                    logger.error(
-                        f"Unimplemented for version of AWS Lambda Runtime Interface Client: {__version__}"
-                    )
-            except ImportError:
-                logger.error(
-                    "Failed to import awslambdaric. A new implementation might be needed for this runtime."
-                )
-
-        if aws_lambda_bootstrap is not None:
             __install_post_invocation_hooks(aws_lambda_bootstrap)
         else:
             logger.error(
-                f"No Python-version-compatible Lambda Runtime hook implementation is available for {sys.version_info}"
+                f"Unimplemented for version of AWS Lambda Runtime Interface Client: {__version__}, {sys.version_info=}"
             )
+    except ImportError:
+        logger.error(
+            "Failed to import awslambdaric. A new implementation might be needed for this runtime."
+        )
+
     except Exception as e:  # pylint: disable=broad-except
         logger.error("Could not register Lambda finalize hooks")
         logger.exception(e)


### PR DESCRIPTION
I don't remember why I originally constrained this to `<3.11` (mypy?) but it made it difficult to install from packages targeting `^3.9` with Poetry.

Also removed some dead code and re-enabled CI for 3.11, 3.12