### PR TITLE
publish a wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-          poetry build -fsdist
+          poetry build
 
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
Instead of making every user build the wheel themselves - which is slower and can go wrong - build and publish it once and for all