### PR TITLE
Allow finalize hooks to be installed on awslambdaric 4.x

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,41 @@
+---
+name: awslambdaric Canary
+
+# Installs the latest awslambdaric (unconstrained) and verifies that
+# xoto3.lam.finalize still installs its post-invocation hook. A new major that
+# finalize does not yet handle turns this job red, signalling that
+# xoto3/lam/finalize.py needs a new supported code path.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+env:
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_ACCESS_KEY_ID: 123456789123456789123
+  AWS_SECRET_ACCESS_KEY: just_to_make_boto3_imports_work
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install poetry
+        run: pipx install "poetry>=2.3,<2.4"
+
+      - run: poetry sync
+
+      - name: Upgrade to latest awslambdaric
+        run: poetry run pip install -U awslambdaric
+
+      - name: Report installed awslambdaric
+        run: poetry run python -c "import awslambdaric; print(awslambdaric.__version__)"
+
+      - name: Finalize hook canary
+        run: poetry run python scripts/canary_check.py

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,17 +40,29 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
-        # Quoted otherwise treated as a float literal (3.10 == 3.1)
-        python-version: ["3.12", "3.13", "3.14"]
+        # Quoted otherwise the version is treated as a float literal (3.10 == 3.1).
+        # Ragged axis: awslambdaric 2.x wheels stop at cp312, 3.x at cp314, 4.x at
+        # cp315, so only installable (python, awslambdaric) pairs are listed.
+        include:
+          - { python-version: "3.12", awslambdaric: ">=2,<3" }
+          - { python-version: "3.12", awslambdaric: ">=3,<4" }
+          - { python-version: "3.13", awslambdaric: ">=3,<4" }
+          - { python-version: "3.14", awslambdaric: ">=3,<4" }
+          - { python-version: "3.12", awslambdaric: ">=4,<5" }
+          - { python-version: "3.13", awslambdaric: ">=4,<5" }
+          - { python-version: "3.14", awslambdaric: ">=4,<5" }
+          - { python-version: "3.15", awslambdaric: ">=4,<5", experimental: true }
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install poetry
         run: pipx install "poetry>=2.3,<2.4"
@@ -63,5 +75,8 @@ jobs:
             ${{ runner.os }}-poetry-${{ matrix.python-version }}-
 
       - run: poetry sync
+
+      - name: Install awslambdaric ${{ matrix.awslambdaric }}
+        run: poetry run pip install "awslambdaric${{ matrix.awslambdaric }}"
 
       - run: poetry run pytest tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### 2.2.0
+
+- Add support for `awslambdaric` 4.x in `xoto3.lam.finalize`. 4.x relocated
+  `post_invocation_result`/`post_invocation_error` onto a shared
+  `BaseLambdaRuntimeClient`; the finalize hook now patches that base class so it
+  applies to both standard and multi-concurrent runtime clients.
+
 ### 2.1.0
 
 - Drop support for Python 3.9, 3.10, and 3.11; minimum is now Python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xoto3"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Peter Gaultney <pgaultney@xoi.io>"]
 description = "High level utilities for a subset of boto3 operations common for AWS serverless development in Python."
 readme = "README.md"

--- a/scripts/canary_check.py
+++ b/scripts/canary_check.py
@@ -1,0 +1,49 @@
+"""Canary check for xoto3.lam.finalize against the installed awslambdaric.
+
+Run on a schedule (see .github/workflows/canary.yml) with the *latest*
+awslambdaric installed. It verifies that finalize actually installs its
+post-invocation hook onto the real runtime client. If a new awslambdaric major
+ships that finalize does not yet handle, the hook is not installed, the thunk
+never fires, and this script exits non-zero -- signalling that
+xoto3/lam/finalize.py needs a new supported code path.
+
+This deliberately exercises the *real* awslambdaric wheel, complementing the
+hermetic, synthetic-package unit tests in tests/xoto3/lam/finalize_test.py.
+"""
+
+import os
+
+# finalize only installs hooks in a Lambda-like environment; make is_aws_env()
+# true before importing the module (its one-time setup runs at import).
+os.environ.setdefault("AWS_EXECUTION_ENV", "canary")
+
+import awslambdaric  # noqa: E402
+from awslambdaric import bootstrap  # noqa: E402
+
+import xoto3.lam.finalize as finalize  # noqa: E402
+
+version = awslambdaric.__version__
+major = version.split(".")[0]
+
+fired: list = []
+finalize.register_lambda_finalize_thunk(lambda: fired.append(True))
+
+# bootstrap.LambdaRuntimeClient exists in every major; its post_invocation_result
+# resolves to the finalize-wrapped method either directly (2.x/3.x) or via the
+# patched BaseLambdaRuntimeClient (4.x). Construction opens no connection.
+client = bootstrap.LambdaRuntimeClient("127.0.0.1:9001")
+try:
+    client.post_invocation_result("canary-request-id", "{}", "application/json")
+except Exception:
+    # The wrapped original then calls into the absent native runtime client;
+    # we only care that our finalize thunk ran first.
+    pass
+
+if not fired:
+    raise SystemExit(
+        f"FINALIZE CANARY FAILED: awslambdaric {version} (major {major}) is installed, "
+        f"but xoto3.lam.finalize did not install its post-invocation hook. "
+        f"A new major likely needs a supported code path in xoto3/lam/finalize.py."
+    )
+
+print(f"OK: finalize hooks installed against awslambdaric {version} (major {major}).")

--- a/tests/xoto3/lam/finalize_test.py
+++ b/tests/xoto3/lam/finalize_test.py
@@ -1,0 +1,149 @@
+"""Tests for xoto3.lam.finalize's awslambdaric version-aware hook installation.
+
+finalize.py installs its post-invocation hooks at import time, keyed off the
+installed awslambdaric major version. To exercise each supported version
+independently (and avoid the module-load-time state that would otherwise make
+these order-dependent), every scenario runs in a fresh interpreter against a
+synthetic ``awslambdaric`` package placed on ``PYTHONPATH``.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_FOUR_X_CLIENT = """
+class BaseLambdaRuntimeClient:
+    def post_invocation_result(self, *a, **k):
+        return ("orig_result", a, k)
+    def post_invocation_error(self, *a, **k):
+        return ("orig_error", a, k)
+class LambdaRuntimeClient(BaseLambdaRuntimeClient):
+    pass
+class LambdaMultiConcurrentRuntimeClient(BaseLambdaRuntimeClient):
+    pass
+"""
+
+_LEGACY_CLIENT = """
+class LambdaRuntimeClient:
+    def post_invocation_result(self, *a, **k):
+        return ("orig_result", a, k)
+    def post_invocation_error(self, *a, **k):
+        return ("orig_error", a, k)
+"""
+
+
+def _write_fake_awslambdaric(base: Path, version: str, four_x: bool) -> None:
+    pkg = base / "awslambdaric"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text(f'__version__ = "{version}"\n')
+    (pkg / "lambda_runtime_client.py").write_text(_FOUR_X_CLIENT if four_x else _LEGACY_CLIENT)
+    (pkg / "bootstrap.py").write_text("from .lambda_runtime_client import LambdaRuntimeClient\n")
+
+
+def _run_driver(base: Path, driver: str) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "AWS_EXECUTION_ENV": "AWS_Lambda_python3.12",
+        "PYTHONPATH": os.pathsep.join([str(base), str(REPO_ROOT)]),
+    }
+    return subprocess.run(
+        [sys.executable, "-c", driver],
+        env=env,
+        cwd=str(base),
+        capture_output=True,
+        text=True,
+    )
+
+
+_LEGACY_DRIVER = textwrap.dedent(
+    """
+    calls = []
+    import xoto3.lam.finalize as F
+    F.register_lambda_finalize_thunk(lambda: calls.append("thunk"))
+    from awslambdaric.lambda_runtime_client import LambdaRuntimeClient
+
+    inst = LambdaRuntimeClient()
+    r = inst.post_invocation_result("id", "data", "ct")
+    assert calls == ["thunk"], calls
+    assert r[0] == "orig_result", r
+    calls.clear()
+    e = inst.post_invocation_error("id", "err", "xray")
+    assert calls == ["thunk"], calls
+    assert e[0] == "orig_error", e
+    print("OK")
+    """
+)
+
+_FOUR_X_DRIVER = textwrap.dedent(
+    """
+    calls = []
+    import xoto3.lam.finalize as F
+    F.register_lambda_finalize_thunk(lambda: calls.append("thunk"))
+    from awslambdaric.lambda_runtime_client import (
+        LambdaRuntimeClient,
+        LambdaMultiConcurrentRuntimeClient,
+    )
+
+    # 4.x passes an extra invocation_id positional; the wrapper is signature-agnostic.
+    r = LambdaRuntimeClient().post_invocation_result("id", "data", "ct", "iid")
+    assert calls == ["thunk"], calls
+    assert r[0] == "orig_result", r
+    calls.clear()
+    e = LambdaRuntimeClient().post_invocation_error("id", "err", "xray", "iid")
+    assert calls == ["thunk"], calls
+    assert e[0] == "orig_error", e
+    # Multi-concurrent mode uses a sibling client; patching the shared base must cover it.
+    calls.clear()
+    LambdaMultiConcurrentRuntimeClient().post_invocation_result("id", "data", "ct", "iid")
+    assert calls == ["thunk"], calls
+    print("OK")
+    """
+)
+
+
+def test_hooks_fire_for_awslambdaric_2x(tmp_path):
+    _write_fake_awslambdaric(tmp_path, "2.2.1", four_x=False)
+    p = _run_driver(tmp_path, _LEGACY_DRIVER)
+    assert p.returncode == 0, p.stderr
+    assert p.stdout.strip() == "OK"
+
+
+def test_hooks_fire_for_awslambdaric_3x(tmp_path):
+    _write_fake_awslambdaric(tmp_path, "3.1.1", four_x=False)
+    p = _run_driver(tmp_path, _LEGACY_DRIVER)
+    assert p.returncode == 0, p.stderr
+    assert p.stdout.strip() == "OK"
+
+
+def test_hooks_fire_for_awslambdaric_4x_standard_and_multiconcurrent(tmp_path):
+    _write_fake_awslambdaric(tmp_path, "4.0.2", four_x=True)
+    p = _run_driver(tmp_path, _FOUR_X_DRIVER)
+    assert p.returncode == 0, p.stderr
+    assert p.stdout.strip() == "OK"
+
+
+def test_unsupported_major_version_logs_error_and_does_not_patch(tmp_path):
+    _write_fake_awslambdaric(tmp_path, "5.0.0", four_x=False)
+    driver = textwrap.dedent(
+        """
+        import io, logging
+        buf = io.StringIO()
+        logging.basicConfig(stream=buf, level=logging.ERROR)
+        calls = []
+        import xoto3.lam.finalize as F
+        F.register_lambda_finalize_thunk(lambda: calls.append("thunk"))
+        from awslambdaric.lambda_runtime_client import LambdaRuntimeClient
+
+        assert LambdaRuntimeClient().post_invocation_result() == ("orig_result", (), {})
+        assert calls == [], "thunk must not fire on unsupported version"
+        assert "Unimplemented" in buf.getvalue(), buf.getvalue()
+        print("OK")
+        """
+    )
+    p = _run_driver(tmp_path, driver)
+    assert p.returncode == 0, p.stderr
+    assert p.stdout.strip() == "OK"

--- a/xoto3/lam/finalize.py
+++ b/xoto3/lam/finalize.py
@@ -44,14 +44,14 @@ def _noop(*_args, **_kwargs):
     pass
 
 
-def __install_post_invocation_hooks(aws_lambda_bootstrap):
-    aws_lambda_bootstrap.LambdaRuntimeClient.post_invocation_result = _run_thunks_before_function(
+def __install_post_invocation_hooks(runtime_client_class):
+    runtime_client_class.post_invocation_result = _run_thunks_before_function(
         _POST_INVOCATION_RESULT_THUNKS
-    )(aws_lambda_bootstrap.LambdaRuntimeClient.post_invocation_result)
+    )(runtime_client_class.post_invocation_result)
 
-    aws_lambda_bootstrap.LambdaRuntimeClient.post_invocation_error = _run_thunks_before_function(
+    runtime_client_class.post_invocation_error = _run_thunks_before_function(
         _POST_INVOCATION_ERROR_THUNKS
-    )(aws_lambda_bootstrap.LambdaRuntimeClient.post_invocation_error)
+    )(runtime_client_class.post_invocation_error)
 
 
 def __setup_lambda_finalize_hook():
@@ -67,10 +67,21 @@ def __setup_lambda_finalize_hook():
     try:
         from awslambdaric import __version__  # pylint: disable=import-outside-toplevel
 
-        if __version__.split(".")[0] in {"2", "3"}:
+        major = __version__.split(".")[0]
+        if major in {"2", "3"}:
             import awslambdaric.bootstrap as aws_lambda_bootstrap  # pylint: disable=import-outside-toplevel,import-error
 
-            __install_post_invocation_hooks(aws_lambda_bootstrap)
+            __install_post_invocation_hooks(aws_lambda_bootstrap.LambdaRuntimeClient)
+        elif major == "4":
+            # 4.x moved post_invocation_result/error onto BaseLambdaRuntimeClient,
+            # shared by LambdaRuntimeClient (standard mode) and
+            # LambdaMultiConcurrentRuntimeClient (multi-concurrent mode); patching the
+            # base class covers every runtime code path.
+            from awslambdaric.lambda_runtime_client import (  # pylint: disable=import-outside-toplevel,import-error
+                BaseLambdaRuntimeClient,
+            )
+
+            __install_post_invocation_hooks(BaseLambdaRuntimeClient)
         else:
             logger.error(
                 f"Unimplemented for version of AWS Lambda Runtime Interface Client: {__version__}, {sys.version_info=}"


### PR DESCRIPTION
## Summary

- Adds support for `awslambdaric` 4.x in `xoto3.lam.finalize`, mirroring #37 (which did the same for 3.x).
- 4.x ships **Lambda Managed Instances (LMI) / multi-concurrent** support ([aws/aws-lambda-python-runtime-interface-client#200](https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/200)). That refactor relocated `post_invocation_result`/`post_invocation_error` off `LambdaRuntimeClient` onto a new shared `BaseLambdaRuntimeClient`.
- Two concrete clients now inherit that base: `LambdaRuntimeClient` (standard mode) and `LambdaMultiConcurrentRuntimeClient` (multi-concurrent mode). Patching the **base class** for 4.x makes the finalize hooks fire in *both* runtime paths — patching only `LambdaRuntimeClient` would silently skip multi-concurrent workers.
- The runtime interface `finalize` relies on is otherwise unchanged; 4.x adds an `invocation_id` positional to the post-invocation methods, which the existing `*args, **kwargs` wrapper already absorbs.
- 2.x/3.x behavior is untouched; unsupported majors still log the existing "Unimplemented" error.

## Changes

**`xoto3/lam/finalize.py`**
- Generalize `__install_post_invocation_hooks` to take the target client class instead of the `bootstrap` module.
- Version branch: 2.x/3.x → patch `bootstrap.LambdaRuntimeClient`; 4.x → patch `lambda_runtime_client.BaseLambdaRuntimeClient`; else log unimplemented.

**`tests/xoto3/lam/finalize_test.py`** (new; finalize previously had no coverage)
- Each version runs in a fresh interpreter against a synthetic `awslambdaric` package (sidesteps import-time hook-install state).
- Asserts hooks fire for 2.x, 3.x, 4.x standard **and** multi-concurrent clients, and that an unsupported major logs an error without patching.

**`pyproject.toml` / `CHANGES.md`**
- Version `2.1.0` → `2.2.0` + changelog entry. (Dev-dep bound `awslambdaric = ">=2.0.0"` already permits 4.x — unchanged.)

## Testing

- `poetry run pytest tests` → **125 passed** (new finalize tests included).
- `poetry run mypy xoto3` → clean (also clean on the new test file).
- `black` / `isort` applied per the pinned pre-commit revs.
